### PR TITLE
Fix syntax error in before deploying task to support capistrano 3.1

### DIFF
--- a/lib/capistrano/tasks/inspeqtor.cap
+++ b/lib/capistrano/tasks/inspeqtor.cap
@@ -6,9 +6,7 @@ namespace :load do
 end
 
 namespace :deploy do
-  before :starting do
-      invoke 'inspeqtor:add_default_hooks'
-  end
+  before :starting, 'inspeqtor:add_default_hooks'
 end
 
 namespace :inspeqtor do


### PR DESCRIPTION
This changed in capistrano's syntax in 3.1
